### PR TITLE
Fixes typo for interests' summary

### DIFF
--- a/resume.hbs
+++ b/resume.hbs
@@ -602,7 +602,7 @@
 										{{/each}}
 									</ul>
 								{{/if}}
-								{{#if syummary}}
+								{{#if summary}}
 								<div class="summary">
 									<p>{{paragraphSplit summary}}</p>
 								</div>


### PR DESCRIPTION
Interest summaries weren't rendered because of a typo.