### PR TITLE
Prevent word breaks in very long lines

### DIFF
--- a/style.css
+++ b/style.css
@@ -522,7 +522,7 @@ ul.courses li:hover {
     .header-left {
         float: left;
         width: 70%;
-        word-break: break-all;
+        word-break: normal;
     }
 
     .section header .date {


### PR DESCRIPTION
Since word breaks are not shown with a hyphen, this behaviour leads to a
sloppy-looking CV. Of course, this may be a matter of opinion, so you're free
to disregard this suggestion if you disagree. Cheers.