### PR TITLE
Add a space in ::before separators

### DIFF
--- a/style.css
+++ b/style.css
@@ -268,7 +268,7 @@ h2.section-title {
 .institution::before,
 .organization::before,
 .awarder::before {
-    content: "at"
+    content: "at "
 }
 
 .company,
@@ -516,7 +516,7 @@ ul.courses li:hover {
     .institution::before,
     .organization::before,
     .awarder::before {
-        content: "|";
+        content: "| ";
     }
 
     .header-left {
@@ -563,7 +563,7 @@ ul.courses li:hover {
     .institution::before,
     .organization::before,
     .awarder::before {
-        content: "at";
+        content: "at ";
     }
 
     .main-summary {


### PR DESCRIPTION
`::before` selector contents aren't typically separated when rendered from the content of the selected element. Therefore, a space is inserted in the respective values to compensate.

On a sidenote, the affected ruleset under `@media print` has the same value as the common ruleset, and can be skipped.