### PR TITLE
Add some features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# It's Modified Version of Stack Overflow theme for jsonresume ![jsonresume-theme-stackoverflow](https://github.com/francescoes/jsonresume-theme-stackoverflow)
+# It's Modified Version of Stack Overflow theme for jsonresume ([jsonresume-theme-stackoverflow](https://github.com/francescoes/jsonresume-theme-stackoverflow))
 
 ## Modified Features
 
 1. Open website links in new tab
 
-2. Highlights allows html tags(<a> for link, <br> for line breaking, ...)
+2. Highlights allows html tags(`<a>` for link, `<br>` for line breaking, ...)
 
 3. Website links in Volunteer section looks more comfortable
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # It's Modified Version of Stack Overflow theme for jsonresume ([jsonresume-theme-stackoverflow](https://github.com/francescoes/jsonresume-theme-stackoverflow))
 
+## [Demo](http://themes.jsonresume.org/theme/curzy)
+
 ## Modified Features
 
 1. Open website links in new tab

--- a/README.md
+++ b/README.md
@@ -1,88 +1,12 @@
-# Stack Overflow theme for jsonresume [![npm version](https://badge.fury.io/js/jsonresume-theme-stackoverflow.svg)](http://badge.fury.io/js/jsonresume-theme-stackoverflow)
+# It's Modified Version of Stack Overflow theme for jsonresume ![jsonresume-theme-stackoverflow](https://github.com/francescoes/jsonresume-theme-stackoverflow)
 
-**Printable version with custom CSS**
+## Modified Features
 
-[DEMO](https://themes.jsonresume.org/stackoverflow)
+1. Open website links in new tab
 
-## Getting started
+2. Highlights allows html tags(<a> for link, <br> for line breaking, ...)
 
-### Install the command line
-
-Create your resume in json on [jsonresume](https://jsonresume.org)
-
-The official [resume-cli](https://github.com/jsonresume/resume-cli) to run the development server.
-
-Go ahead and install it:
-
-```
-sudo npm install -g resume-cli
-```
-### Install and serve theme
-
-This is a theme for JSON Resume. It is available via npm:
-
-```
-npm install jsonresume-theme-stackoverflow
-```
-
-then change directory: 
-
-`cd node_modules/jsonresume-theme-stackoverflow/`
-
-And simply run:
-
-```
-resume serve
-```
-
-You should now see this message:
-
-```
-Preview: http://localhost:4000
-Press ctrl-c to stop
-```
-
-### Social Profiles Icons
-
-**Profiles supported with brand colors:**
-
-github, stack overflow, linkedin, dribbble, twitter, facebook, pinterest, instagram, soundcloud, wordpress, youtube, flickr, google plus, tumblr, foursquare.
-
-To have a social icon close the social link profile (or username) it is enough to set a `network` the name of the Social Network (es: 'Stack Overflow').
-
-#### Support to extra fields
-
-With stackoverflow theme it is possible to add:
-
-- `keywords` to each 'work', 'publication' and 'volunteer' item
-- `summary` to each 'interests' and 'education' item
-- `location` to each 'work', 'education' and 'volunteer' item
-- `birth` to 'basics'
-
-example of the extra `location` object: 
-
-```
-"location": {
-	"city": "Zürich",
-	"countryCode": "CH",
-	"region": "Switzerland"
-} 
-```
-example of the extra `birth` object:
-
-```
-"birth": {
-  "place": "New York",
-  "state": "USA",
-  "date": "1988"
-}
-```
-
-## Contribution
-
-Fork the project, add your feature (or fix your bug) and open a pull request OR
-
-[Open an issue](https://github.com/francescoes/jsonresume-theme-stackoverflow/issues/new) if you find find or if you would like to have extra fields or changes 
+3. Website links in Volunteer section looks more comfortable
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-curzy",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Modified JSON Resume theme from Stack Overflow theme",
   "author": "Curzy <https://github.com/Curzy>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-curzy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Modified JSON Resume theme from Stack Overflow theme",
   "author": "Curzy <https://github.com/Curzy>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "jsonresume-theme-stackoverflow",
-  "version": "1.0.4",
-  "description": "Stack Overflow theme for JSON Resume",
-  "author": "Francesco Esposito <http://fran.cesco.io>",
+  "name": "jsonresume-theme-curzy",
+  "version": "1.0.0",
+  "description": "Modified JSON Resume theme from Stack Overflow theme",
+  "author": "Curzy <https://github.com/Curzy>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/francescoes/jsonresume-theme-stackoverflow"
+    "url": "https://github.com/Curzy/jsonresume-theme-curzy"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-curzy",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Modified JSON Resume theme from Stack Overflow theme",
   "author": "Curzy <https://github.com/Curzy>",
   "repository": {

--- a/resume.hbs
+++ b/resume.hbs
@@ -62,7 +62,7 @@
 						{{#if website}}
 						<div class="website">
               <span class="fa fa-external-link"></span>
-							<a target="_blank" href="{{website}}">{{website}}</a>
+							<a target="_blank" target="_blank" href="{{website}}">{{website}}</a>
 						</div>
 						{{/if}}
 						{{#if email}}
@@ -88,7 +88,7 @@
 									<span class="fa fa-{{spaceToDash network}} {{spaceToDash network}} social"></span>
 									{{#if url}}
 									<span class="url">
-										<a href="{{url}}">{{username}}</a>
+										<a target="_blank" href="{{url}}">{{username}}</a>
 									</span>
 									{{else}}
 										<span>{{username}}</span>
@@ -184,33 +184,31 @@
 									</div>
 								</header>
 							{{/if}}
-
-                             {{#location}}
-                                <span class="location">
-                                    <span class="fa fa-map-marker"></span>
-                                    {{#if city}}
-                                    <span class="city">
-                                        {{city}},
-                                    </span>
-                                    {{/if}}
-                                    {{#if countryCode}}
-                                    <span class="countryCode">
-                                        ({{countryCode}})
-                                    </span>
-                                    {{/if}}
-                                    {{#if region}}
-                                    <span class="region">
-                                      {{region}}
-                                    </span>
-                                    {{/if}}
-                                </span>
-                            {{/location}}
-                            {{#if website}}
-                                <span class="website">
-                                    <a href="{{website}}">{{website}}</a>
-                                </span>
-                            {{/if}}
-
+                {{#location}}
+                    <span class="location">
+                        <span class="fa fa-map-marker"></span>
+                        {{#if city}}
+                        <span class="city">
+                            {{city}},
+                        </span>
+                        {{/if}}
+                        {{#if countryCode}}
+                        <span class="countryCode">
+                            ({{countryCode}})
+                        </span>
+                        {{/if}}
+                        {{#if region}}
+                        <span class="region">
+                          {{region}}
+                        </span>
+                        {{/if}}
+                    </span>
+                {{/location}}
+                {{#if website}}
+                    <span class="website">
+                        <a target="_blank" href="{{website}}">{{website}}</a>
+                    </span>
+                {{/if}}
 							{{#if keywords.length}}
 								<ul class="keywords">
 									{{#each keywords}}
@@ -304,7 +302,7 @@
                             {{/location}}
                             {{#if url}}
                                 <span class="website">
-                                    <a href="{{url}}">{{url}}</a>
+                                    <a target="_blank" href="{{url}}">{{url}}</a>
                                 </span>
                             {{/if}}
 
@@ -425,7 +423,7 @@
 								{{/if}}
 								{{#if website}}
 									<div class="website">
-										<a href="{{website}}">{{website}}</a>
+										<a target="_blank" href="{{website}}">{{website}}</a>
 									</div>
 								{{/if}}
 								{{#if highlights.length}}
@@ -610,7 +608,7 @@
 										<span class="name">
 											{{#if website}}
 											<span class="website">
-												<a href="{{website}}">{{name}}</a>
+												<a target="_blank" href="{{website}}">{{name}}</a>
 											</span>
 											{{else}}
 												{{name}}

--- a/resume.hbs
+++ b/resume.hbs
@@ -184,31 +184,31 @@
 									</div>
 								</header>
 							{{/if}}
-                {{#location}}
-                    <span class="location">
-                        <span class="fa fa-map-marker"></span>
-                        {{#if city}}
-                        <span class="city">
-                            {{city}},
-                        </span>
-                        {{/if}}
-                        {{#if countryCode}}
-                        <span class="countryCode">
-                            ({{countryCode}})
-                        </span>
-                        {{/if}}
-                        {{#if region}}
-                        <span class="region">
-                          {{region}}
-                        </span>
-                        {{/if}}
-                    </span>
-                {{/location}}
-                {{#if website}}
-                    <span class="website">
-                        <a target="_blank" href="{{website}}">{{website}}</a>
-                    </span>
-                {{/if}}
+              {{#location}}
+                  <span class="location">
+                      <span class="fa fa-map-marker"></span>
+                      {{#if city}}
+                      <span class="city">
+                          {{city}},
+                      </span>
+                      {{/if}}
+                      {{#if countryCode}}
+                      <span class="countryCode">
+                          ({{countryCode}})
+                      </span>
+                      {{/if}}
+                      {{#if region}}
+                      <span class="region">
+                        {{region}}
+                      </span>
+                      {{/if}}
+                  </span>
+              {{/location}}
+              {{#if website}}
+                  <span class="website">
+                      <a target="_blank" href="{{website}}">{{website}}</a>
+                  </span>
+              {{/if}}
 							{{#if keywords.length}}
 								<ul class="keywords">
 									{{#each keywords}}
@@ -381,6 +381,11 @@
 									</div>
 								</header>
 							{{/if}}
+							{{#if website}}
+								<div class="website">
+									<a target="_blank" href="{{website}}">{{website}}</a>
+								</div>
+							{{/if}}
 
               {{#location}}
                 <span class="location">
@@ -419,11 +424,6 @@
 								{{#if summary}}
 									<div class="summary">
 										<p>{{paragraphSplit summary}}</p>
-									</div>
-								{{/if}}
-								{{#if website}}
-									<div class="website">
-										<a target="_blank" href="{{website}}">{{website}}</a>
 									</div>
 								{{/if}}
 								{{#if highlights.length}}

--- a/resume.hbs
+++ b/resume.hbs
@@ -230,7 +230,7 @@
 								{{#if highlights.length}}
 									<ul class="highlights">
 										{{#each highlights}}
-											<li>{{.}}</li>
+											<li>{{paragraphSplit .}}</li>
 										{{/each}}
 									</ul>
 								{{/if}}
@@ -327,7 +327,7 @@
 								{{#if highlights.length}}
 									<ul class="highlights">
 										{{#each highlights}}
-											<li>{{.}}</li>
+											<li>{{paragraphSplit .}}</li>
 										{{/each}}
 									</ul>
 								{{/if}}
@@ -429,7 +429,7 @@
 								{{#if highlights.length}}
 									<ul class="highlights">
 										{{#each highlights}}
-											<li>{{.}}</li>
+											<li>{{paragraphSplit .}}</li>
 										{{/each}}
 									</ul>
 								{{/if}}

--- a/style.css
+++ b/style.css
@@ -88,6 +88,10 @@ li {
     margin-left: 1.3em;
 }
 
+.highlights > li > p {
+  margin-bottom: 0.5em;
+}
+
 h1 {
     font-size: 2rem;
 }

--- a/style.css
+++ b/style.css
@@ -547,7 +547,8 @@ ul.courses li:hover {
 @media print {
 
     #resume {
-        margin: 0;
+        width: 80%;
+        margin: 2rem auto;
         padding: 0;
         -ms-word-wrap: break-word;
         word-wrap: break-word;


### PR DESCRIPTION
1. Open site link in new tab.
When opening company, volunteer, profile websites opening link in current tab may interrupt reading resume.

2. Allow html tags in highlights.
User can emphasize important part in highlight, also can link to describe
like, 
```
blahblahblah contribution resolve problem
<a href='https://github.com/Curzy/wolsemap/pulls' target='_blank'>Pull Requests</a>
```

3. 	Volunteer website link position as Work Experience section
Website link in Volunteer section seems look awkward. 

Before: 
<img width="500" alt="2017-02-17 3 04 14" src="https://cloud.githubusercontent.com/assets/3931792/23034064/d7b06e00-f4bd-11e6-9382-f0b6cbdf23f5.png">

After: 
<img width="500" alt="2017-02-17 3 06 14" src="https://cloud.githubusercontent.com/assets/3931792/23034148/1cbece9c-f4be-11e6-8bb7-ae5fda501e72.png">

Excuse my English :smile:

Regards!

