### PR TITLE
Add some features

### DIFF
--- a/resume.hbs
+++ b/resume.hbs
@@ -62,7 +62,7 @@
 						{{#if website}}
 						<div class="website">
               <span class="fa fa-external-link"></span>
-							<a target="_blank" href="{{website}}">{{website}}</a>
+							<a target="_blank" target="_blank" href="{{website}}">{{website}}</a>
 						</div>
 						{{/if}}
 						{{#if email}}
@@ -88,7 +88,7 @@
 									<span class="fa fa-{{spaceToDash network}} {{spaceToDash network}} social"></span>
 									{{#if url}}
 									<span class="url">
-										<a href="{{url}}">{{username}}</a>
+										<a target="_blank" href="{{url}}">{{username}}</a>
 									</span>
 									{{else}}
 										<span>{{username}}</span>
@@ -184,33 +184,31 @@
 									</div>
 								</header>
 							{{/if}}
-
-                             {{#location}}
-                                <span class="location">
-                                    <span class="fa fa-map-marker"></span>
-                                    {{#if city}}
-                                    <span class="city">
-                                        {{city}},
-                                    </span>
-                                    {{/if}}
-                                    {{#if countryCode}}
-                                    <span class="countryCode">
-                                        ({{countryCode}})
-                                    </span>
-                                    {{/if}}
-                                    {{#if region}}
-                                    <span class="region">
-                                      {{region}}
-                                    </span>
-                                    {{/if}}
-                                </span>
-                            {{/location}}
-                            {{#if website}}
-                                <span class="website">
-                                    <a href="{{website}}">{{website}}</a>
-                                </span>
-                            {{/if}}
-
+                {{#location}}
+                    <span class="location">
+                        <span class="fa fa-map-marker"></span>
+                        {{#if city}}
+                        <span class="city">
+                            {{city}},
+                        </span>
+                        {{/if}}
+                        {{#if countryCode}}
+                        <span class="countryCode">
+                            ({{countryCode}})
+                        </span>
+                        {{/if}}
+                        {{#if region}}
+                        <span class="region">
+                          {{region}}
+                        </span>
+                        {{/if}}
+                    </span>
+                {{/location}}
+                {{#if website}}
+                    <span class="website">
+                        <a target="_blank" href="{{website}}">{{website}}</a>
+                    </span>
+                {{/if}}
 							{{#if keywords.length}}
 								<ul class="keywords">
 									{{#each keywords}}
@@ -304,7 +302,7 @@
                             {{/location}}
                             {{#if url}}
                                 <span class="website">
-                                    <a href="{{url}}">{{url}}</a>
+                                    <a target="_blank" href="{{url}}">{{url}}</a>
                                 </span>
                             {{/if}}
 
@@ -425,7 +423,7 @@
 								{{/if}}
 								{{#if website}}
 									<div class="website">
-										<a href="{{website}}">{{website}}</a>
+										<a target="_blank" href="{{website}}">{{website}}</a>
 									</div>
 								{{/if}}
 								{{#if highlights.length}}
@@ -610,7 +608,7 @@
 										<span class="name">
 											{{#if website}}
 											<span class="website">
-												<a href="{{website}}">{{name}}</a>
+												<a target="_blank" href="{{website}}">{{name}}</a>
 											</span>
 											{{else}}
 												{{name}}

--- a/resume.hbs
+++ b/resume.hbs
@@ -184,31 +184,31 @@
 									</div>
 								</header>
 							{{/if}}
-                {{#location}}
-                    <span class="location">
-                        <span class="fa fa-map-marker"></span>
-                        {{#if city}}
-                        <span class="city">
-                            {{city}},
-                        </span>
-                        {{/if}}
-                        {{#if countryCode}}
-                        <span class="countryCode">
-                            ({{countryCode}})
-                        </span>
-                        {{/if}}
-                        {{#if region}}
-                        <span class="region">
-                          {{region}}
-                        </span>
-                        {{/if}}
-                    </span>
-                {{/location}}
-                {{#if website}}
-                    <span class="website">
-                        <a target="_blank" href="{{website}}">{{website}}</a>
-                    </span>
-                {{/if}}
+              {{#location}}
+                  <span class="location">
+                      <span class="fa fa-map-marker"></span>
+                      {{#if city}}
+                      <span class="city">
+                          {{city}},
+                      </span>
+                      {{/if}}
+                      {{#if countryCode}}
+                      <span class="countryCode">
+                          ({{countryCode}})
+                      </span>
+                      {{/if}}
+                      {{#if region}}
+                      <span class="region">
+                        {{region}}
+                      </span>
+                      {{/if}}
+                  </span>
+              {{/location}}
+              {{#if website}}
+                  <span class="website">
+                      <a target="_blank" href="{{website}}">{{website}}</a>
+                  </span>
+              {{/if}}
 							{{#if keywords.length}}
 								<ul class="keywords">
 									{{#each keywords}}
@@ -381,6 +381,11 @@
 									</div>
 								</header>
 							{{/if}}
+							{{#if website}}
+								<div class="website">
+									<a target="_blank" href="{{website}}">{{website}}</a>
+								</div>
+							{{/if}}
 
               {{#location}}
                 <span class="location">
@@ -419,11 +424,6 @@
 								{{#if summary}}
 									<div class="summary">
 										<p>{{paragraphSplit summary}}</p>
-									</div>
-								{{/if}}
-								{{#if website}}
-									<div class="website">
-										<a target="_blank" href="{{website}}">{{website}}</a>
 									</div>
 								{{/if}}
 								{{#if highlights.length}}

--- a/resume.hbs
+++ b/resume.hbs
@@ -230,7 +230,7 @@
 								{{#if highlights.length}}
 									<ul class="highlights">
 										{{#each highlights}}
-											<li>{{.}}</li>
+											<li>{{paragraphSplit .}}</li>
 										{{/each}}
 									</ul>
 								{{/if}}
@@ -327,7 +327,7 @@
 								{{#if highlights.length}}
 									<ul class="highlights">
 										{{#each highlights}}
-											<li>{{.}}</li>
+											<li>{{paragraphSplit .}}</li>
 										{{/each}}
 									</ul>
 								{{/if}}
@@ -429,7 +429,7 @@
 								{{#if highlights.length}}
 									<ul class="highlights">
 										{{#each highlights}}
-											<li>{{.}}</li>
+											<li>{{paragraphSplit .}}</li>
 										{{/each}}
 									</ul>
 								{{/if}}

--- a/style.css
+++ b/style.css
@@ -88,6 +88,10 @@ li {
     margin-left: 1.3em;
 }
 
+.highlights > li > p {
+  margin-bottom: 0.5em;
+}
+
 h1 {
     font-size: 2rem;
 }


### PR DESCRIPTION
1. Open site link in new tab.
When opening company, volunteer, profile websites opening link in current tab may interrupt reading resume.

2. Allow html tags in highlights.
User can emphasize important part in highlight, also can link to describe
like, 
```
blahblahblah contribution resolve problem
<a href='https://github.com/Curzy/wolsemap/pulls' target='_blank'>Pull Requests</a>
```

3. 	Volunteer website link position as Work Experience section
Website link in Volunteer section seems look awkward. 

Before: 
<img width="500" alt="2017-02-17 3 04 14" src="https://cloud.githubusercontent.com/assets/3931792/23034064/d7b06e00-f4bd-11e6-9382-f0b6cbdf23f5.png">

After: 
<img width="500" alt="2017-02-17 3 06 14" src="https://cloud.githubusercontent.com/assets/3931792/23034148/1cbece9c-f4be-11e6-8bb7-ae5fda501e72.png">

Excuse my English :smile:

Regards!

