### PR TITLE
adding missing main and removing dev dep as it causes resume to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,9 @@
     "url": "https://github.com/francescoes/jsonresume-theme-stackoverflow"
   },
   "license": "MIT",
+  "main": "index.js",
   "dependencies": {
     "handlebars": "^4.0.10",
     "moment": "^2.18.1"
-  },
-  "devDependencies": {
-    "require-dir": "^0.3.2"
   }
 }


### PR DESCRIPTION
currently i have to install `require-dir` in order to get this theme to work with resume. removing the devDependencies fixes the theme.

```
# resume export --theme stackoverflow resume.html

  running validation tests on resume.json ... 

  ✓ Passed all validation tests. 

To publish your resume at http://jsonresume.org type the command resume publish
You have to install this theme globally to use it e.g. `npm install -g jsonresume-theme-stackoverflow`
```

here is an example Dockerfile showing the error if you try and make a resume
```Dockerfile
FROM alpine:latest

RUN apk --no-cache add \
      nodejs-npm \
    && npm install -g \
         resume-cli \
         jsonresume-theme-stackoverflow

ENTRYPOINT ["resume"]
```