### PR TITLE
add a link on the phone number

### DIFF
--- a/theme/partials/basics.hbs
+++ b/theme/partials/basics.hbs
@@ -51,7 +51,8 @@
 			{{/if}} 
 			{{#if phone}}
 			<div class="phone">
-				<span class="fa fa-mobile"></span> {{phone}}
+				<span class="fa fa-mobile"></span>
+				<a href="tel:{{phone}}">{{phone}}</a>
 			</div>
 			{{/if}}
 		</div>


### PR DESCRIPTION
adding the `tel:` link on a phone number allows the browser to initiate a call when clicked