### PR TITLE
Add clear fix

### DIFF
--- a/theme/partials/education.hbs
+++ b/theme/partials/education.hbs
@@ -15,7 +15,7 @@
         {{/if}}
         <label for="education-item-{{@index}}"></label>
       {{/if}}
-      <header>
+      <header class="clear">
         <div class="header-left">
           {{#if studyType}}
           <div class="studyType">


### PR DESCRIPTION
As you can see in the screenshot, the keywords for the eduction item are mixed with the header and the date.
The reason is the header has 2 floated items and no clearfix. Because of this, the element has height = 0 creating the issue.

<img width="918" alt="screen shot 2018-01-21 at 18 27 35" src="https://user-images.githubusercontent.com/2573159/35196914-cd8b095a-fed8-11e7-8afd-078f758d7de6.png">
