### PR TITLE
Minor fix at css, causing some selction box to moove while selecting …

### DIFF
--- a/style.css
+++ b/style.css
@@ -627,7 +627,6 @@ ul.courses li:hover {
     }
     .toggle-item+label {
         display: block;
-        margin-top: -16px;
     }
     .toggle-item:checked+label:after {
         content: '\f0d7';


### PR DESCRIPTION
…another box

Hi guys!

I have made a minor correction to this CSS class > .toggle-item+label

I don't see why its necessary and ended up bugging some selection boxes of my built resume.

I have tested on my end and when removing the line, the template builds the html perfectly, please check the two html:

With the 16px line (minimize both awards boxes)
http://cv.felipe.cloud/

Without the 16px line, my PR code (play around the award boxes)
http://cv.felipe.cloud/index-2.html

Please let me know your feedback! Thank you for this awesome template! 
